### PR TITLE
Clarify phrasing.

### DIFF
--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -50,7 +50,7 @@
                 <p>The State of Geneva is pioneering in the e-voting domain with over <em>100 polls</em> successfully accomplished since
                     2003.
                 </p>
-                <p>CHVote, entirely developed, hosted and exploited by the Geneva Canton is today one of only two accredited electronic voting systems by the Federal
+                <p>CHVote, entirely developed, hosted and operated by the Geneva Canton is today one of only two accredited electronic voting systems by the Federal
                     Council in Switzerland. It is offered to nearly <em>125’000 voters in 4 cantons</em> (Geneva, Bern, Lucerne and Basel),
                     as much for voting as for electing at the communal, cantonal and federal levels. It also allows people with disabilities to
                     participate in the polls.</p>


### PR DESCRIPTION
"Exploited" is a false-friend and has a completely different meaning in English. As highlighted by this snarky [HackerNews comment](https://news.ycombinator.com/item?id=13175674)