### PR TITLE
Add "Security" title to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Contributions are also welcomed, either using pull requests or by submitting iss
 manager will take care of those inputs, lead exchanges around them, and actions could take place according to their 
 relevance, their criticality, and the CHVote development roadmap.
 
+## Security
+
 In case of vulnerability discovery, please use the following email address for coordinated disclosure: security-chvote@etat.ge.ch.
 
 # Licence


### PR DESCRIPTION
Currently it's easy to miss the fact that you would like security vulnerabilities to be submitted by email. I have created a subsection in `Contributing` concerning security issues.