### PR TITLE
Create CHVote build POM file in root directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ addons:
 before_install: "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d `jdk_switcher home oraclejdk8`/jre/lib/security && rm /tmp/policy.zip"
 
 script:
-- cd base-pom && mvn clean install
-- cd ../commons-base && mvn clean install
-- cd ../admin-offline && mvn clean install
+- mvn clean install
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -43,16 +43,10 @@ The following software must be installed to compile and run the application:
 We do not provide support for the use of OpenJDK/OpenJFX. 
 
 ## Compiling
-Compile and install the 3 modules in this sequence:
+Compile and install all modules:
 
 ```Shell
-cd $PROJECT_ROOT/base-pom
-mvn clean install
-
-cd $PROJECT_ROOT/commons-base
-mvn clean install
-
-cd $PROJECT_ROOT/admin-offline
+cd $PROJECT_ROOT
 mvn clean install
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ch.ge.ve</groupId>
+    <artifactId>chvote-build</artifactId>
+    <version>5.2.1.9-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>CHVote Build</name>
+    <description>CHVote Build POM</description>
+
+    <inceptionYear>2015</inceptionYear>
+
+    <modules>
+        <module>base-pom</module>
+        <module>commons-base</module>
+        <module>admin-offline</module>
+    </modules>
+
+    <scm>
+        <connection>scm:git:git://github.com/republique-et-canton-de-geneve/chvote-1-0.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:republique-et-canton-de-geneve/chvote-1-0.git</developerConnection>
+        <url>https://github.com/republique-et-canton-de-geneve/chvote-1-0</url>
+    </scm>
+
+</project>


### PR DESCRIPTION
Hi,
I thus propose this change for the simplification of build process.

If you're agree with that, after I could change all versions, defined in pom files, to 5.2.1.9-SNAPSHOT (for example) and relationships between Maven modules :
- base-pom is the parent of all modules, the same as today, and chvote-build is the parent of base-pom like [apache camel](https://github.com/apache/camel) for example.
or
- base-pom is only the parent of chvote-build and chvote-build is the parent of all other modules like [hibernate-ogm](https://github.com/hibernate/hibernate-ogm) for example.

I'm waiting for your opinion about that Pull Request and I'm available to improve anything in there.