### PR TITLE
README.md: Add a hint to use /dev/urandom instead of /dev/random on Linux...

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ mvn clean install
 cd $PROJECT_ROOT/admin-offline
 mvn clean install
 ```
+On Linux, the Oracle JVM uses the blocking `/dev/random` random device as
+entropy source by default and it will cause long build delays. See
+[Avoiding JVM Delays Caused by Random Number Generation](https://docs.oracle.com/cd/E13209_01/wlcp/wlss30/configwlss/jvmrand.html)
+to workaround this issue.
 
 Some JDK distributions do not come with the Monocle classes used by the headless GUI tests. If you're running into those cases 
 (java.lang.AbstractMethodError: com.sun.glass.ui.monocle.NativePlatform.createInputDeviceRegistry appearing in the test logs),


### PR DESCRIPTION
...when building.

I had very long delay building `commons-base` under Ubuntu 16.04.1 LTS on `ch.ge.ve.commons.crypto.utils.SaltUtilsTest`.