### PR TITLE
Improve constantTimeArrayCompare()

### DIFF
--- a/commons-base/commons-crypto/src/main/java/ch/ge/ve/commons/crypto/SensitiveDataCryptoUtils.java
+++ b/commons-base/commons-crypto/src/main/java/ch/ge/ve/commons/crypto/SensitiveDataCryptoUtils.java
@@ -423,6 +423,10 @@ public class SensitiveDataCryptoUtils {
     }
 
     private static boolean constantTimeArrayCompare(byte[] a1, byte[] a2) {
+        if (a1.length != a2.length) {
+            return false;
+        }
+
         int result = 0;
         for (int i = 0; i < a1.length; i++) {
             result |= a1[i] ^ a2[i];


### PR DESCRIPTION
Now two arrays are equal if they have the same length and all bytes at corresponding positions are equal.